### PR TITLE
fixing onDrop fires twice

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -87,9 +87,7 @@ class ReactImageUploadComponent extends React.Component {
         files.push(newFileData.file);
       });
 
-      this.setState({pictures: dataURLs, files: files}, () => {
-        this.props.onChange(this.state.files, this.state.pictures);
-      });
+      this.setState({pictures: dataURLs, files: files});
     });
   }
 


### PR DESCRIPTION
replicating the pull request for (Issue #88 fixed: onDrop fires twice) in the main repo. https://github.com/JakeHartnell/react-images-upload/pull/95