### PR TITLE
fixing onDrop fired twice

### DIFF
--- a/src/component/compiled.js
+++ b/src/component/compiled.js
@@ -134,9 +134,7 @@ var ReactImageUploadComponent = function (_React$Component) {
           files.push(newFileData.file);
         });
 
-        _this2.setState({ pictures: dataURLs, files: files }, function () {
-          _this2.props.onChange(_this2.state.files, _this2.state.pictures);
-        });
+        _this2.setState({ pictures: dataURLs, files: files });
       });
     }
   }, {


### PR DESCRIPTION
replicating the pull request for (Issue #88 fixed: onDrop fires twice) in the main repo. https://github.com/JakeHartnell/react-images-upload/pull/95